### PR TITLE
[FEAT] add devcontainer config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,41 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-dockerfile
+{
+	"name": "Existing Dockerfile",
+	"workspaceFolder": "/root/catkin_ws",
+	
+	"build": {
+		// Sets the run context to one level up instead of the .devcontainer folder.
+		"context": "..",
+		// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+		"dockerfile": "../Dockerfile"
+	},
+	
+	///mount
+	"mounts": [
+	"source=${localWorkspaceFolder},target=/root/catkin_ws/src/pai,type=bind,consistency=cached"
+	],
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line to run commands after the container is created.
+	"postCreateCommand": "sh ./src/pai/.devcontainer/inside.bash",
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+		  "extensions": [
+			"ms-python.autopep8", 
+			"ms-python.python",
+			"ms-python.vscode-pylance",
+			"ms-iot.vscode-ros",
+			"DavidAnson.vscode-markdownlint"
+		  ]
+		}
+	  }
+	// Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "devcontainer"
+}

--- a/.devcontainer/inside.bash
+++ b/.devcontainer/inside.bash
@@ -1,0 +1,12 @@
+cd ~/catkin_ws
+
+catkin build
+
+source ~/catkin_ws/devel/setup.bash
+#rospack list | grep pai
+
+#roslaunch pai view_robot.launch
+#roslaunch pai sim.launch
+#roslaunch pai sim.launch
+#rosrun pai battery.py
+


### PR DESCRIPTION
The devcontainer facilitates the use of docker for development and testing. It works great with vscode and hopefully it would be helpful when creating github code spaces.
- [x] configure workdir to catkin_ws.
- [x] add vscode extensions.
- [x] runs a script where it `catkin builds` the ROS packages.   
 